### PR TITLE
Be able to export the keyblob path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ ncscope.*
 *~
 \#*#
 
+# Ignore generated binaries and headers.
+caam-keygen
+caam-keygen_header.h

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,14 @@ all : $(TARGET)
 
 $(TARGET): $(OBJS)
 	$(CC) $(CFLAGS) -o $(TARGET) $(OBJS)
+	sed 's;@KEYBLOB_LOCATION@;$(KEYBLOB_LOCATION);g' caam-keygen_header.h.in > caam-keygen_header.h
 
 .PHONY: install
 install: $(TARGET)
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp $< $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+	mkdir -p $(DESTDIR)$(PREFIX)/include
+	cp caam-keygen_header.h $(DESTDIR)$(PREFIX)/include/caam-keygen.h
 
 .PHONY: uninstall
 uninstall:

--- a/caam-keygen.c
+++ b/caam-keygen.c
@@ -28,6 +28,7 @@ void caam_keygen_usage(void)
 	printf("import <blob_name> <key_name>\n");
 	printf("\t<blob_name> the absolute path of the file that contains the blob\n");
 	printf("\t<key_name> the name of the file that will contain the black key.\n");
+	printf("keyblob-location echoes the path to the keyblob location\n");
 }
 
 int caam_keygen_create(char *key_name, char *key_enc, char *key_mode,
@@ -337,6 +338,9 @@ int main(int argc, char *argv[])
 			goto out_usage;
 		blob_name = argv[2];
 		key_name = argv[3];
+	} else if (!strcmp(op, "keyblob-location")) {
+		printf("%s\n", KEYBLOB_LOCATION);
+		return 0;
 	} else {
 		goto out_usage;
 	}

--- a/caam-keygen_header.h.in
+++ b/caam-keygen_header.h.in
@@ -1,0 +1,6 @@
+#ifndef CAMM_KEYGEN_H
+#define CAAM_KEYGEN_H
+
+#define KEYBLOB_LOCATION "@KEYBLOB_LOCATION@"
+
+#endif


### PR DESCRIPTION
The application does an usual thing: harcodes the path on which files are saved. This means that other applications/shell scripts need to know this path beforehand.

This PR:
- Creates and installs a C header file where other C/C++applications can get KEYBLOB_PATH from.
- Adds an option to print the keyblob locaiton path to stdout.
- Adds generated files entries to .gitignore.